### PR TITLE
feat : 이벤트 상세 동작 및 대기열 진입

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,21 +1,29 @@
 // src/components/Header.tsx
-import { Link, useNavigate } from "react-router-dom";
+import { Link, useLocation, useNavigate } from "react-router-dom";
 import { useAuthStore } from "../store/auth.store";
+import { useWaitingStore } from "../store/waiting.store";
 
 export default function Header() {
   const navigate = useNavigate();
+  const location = useLocation();
+  const { isInQueue, leaveQueue } = useWaitingStore();
   const currentUser = useAuthStore((s) => s.currentUser);
   const logout = useAuthStore((s) => s.logout);
 
   const handleLogout = () => {
+    if (isInQueue) {
+      logout();
+      return;
+    }
     logout();
-    navigate("/");
   };
 
   return (
     <header className="w-full">
       <nav className="h-[50px] bg-[#1a6ad4] flex items-center px-6">
-        <Link to="/" className="text-white font-bold text-[20px] tracking-[-0.5px] mr-8">
+        <Link to="/"
+          onClick={() => { if (isInQueue) leaveQueue(); }}
+          className="text-white font-bold text-[20px] tracking-[-0.5px] mr-8">
           티키타카 <sub className="text-[10px] text-white/60 ml-1">TIKITAKA</sub>
         </Link>
 
@@ -23,12 +31,12 @@ export default function Header() {
 
         <div className="flex items-center gap-3">
           {!currentUser ? (
-            <Link
-              to="/login"
+            <button
+              onClick={() => navigate(`/login?redirect=${encodeURIComponent(location.pathname)}`, { replace: true })}
               className="text-[13px] px-4 py-1.5 rounded bg-white text-[#1a6ad4] font-bold"
             >
               로그인
-            </Link>
+            </button>
           ) : (
             <>
               <span className="text-white/90 text-[13px]">{currentUser.name} 님</span>

--- a/src/pages/event/EventDetailPage.tsx
+++ b/src/pages/event/EventDetailPage.tsx
@@ -1,6 +1,8 @@
 // src/pages/event/EventDetailPage.tsx
 import { useState, useEffect } from "react";
 import { useParams, useNavigate } from "react-router-dom";
+import { useAuthStore } from "../../store/auth.store";
+import { useWaitingStore } from "../../store/waiting.store";
 
 // ── 더미 데이터 (HomePage와 동일한 구조)
 type EventStatus = "open" | "soon" | "closing" | "available";
@@ -227,9 +229,11 @@ const TAB_LABELS: { key: TabKey; label: string }[] = [
 
 export default function EventDetailPage() {
   const { eventId } = useParams<{ eventId: string }>();
+  const { enterQueue } = useWaitingStore();
   const navigate = useNavigate();
   const [activeTab, setActiveTab] = useState<TabKey>("info");
 
+  const currentUser = useAuthStore((s) => s.currentUser);
   const event = DUMMY_EVENTS.find((e) => e.id === Number(eventId));
   const countdown = useCountdown(event?.bookingOpenAt ?? new Date());
 
@@ -287,7 +291,15 @@ export default function EventDetailPage() {
                 <div className="flex gap-2">
                   <button
                     disabled={!isOpen}
-                    onClick={() => navigate("/waiting")}
+                    onClick={() => {
+                      if (!currentUser) {
+                        enterQueue(String(event.id));
+                        navigate(`/login?redirect=/waiting&eventId=${eventId}`);
+                        return;
+                      }
+                      enterQueue(String(event.id));
+                      navigate("/waiting", {state: { eventId: String(event.id)} });
+                    }}
                     className={`flex-1 py-2.5 rounded font-bold text-[15px] transition ${
                       isOpen
                         ? "bg-[#1a6ad4] text-white hover:bg-[#1458b0]"
@@ -412,7 +424,15 @@ export default function EventDetailPage() {
                   </div>
 
                   <button
-                    onClick={() => navigate("/waiting")}
+                    onClick={() => {
+                      if (!currentUser) {
+                        enterQueue(String(event.id));
+                        navigate(`/login?redirect=/waiting&eventId=${eventId}`);
+                        return;
+                      }
+                      enterQueue(String(event.id));
+                      navigate("/waiting", { state: { eventId: String(event.id)} });
+                    }}
                     className="w-full py-[14px] bg-[#1a6ad4] text-white rounded font-bold text-[16px] hover:bg-[#1458b0]"
                   >
                     예매하기 →

--- a/src/pages/login/LoginPage.tsx
+++ b/src/pages/login/LoginPage.tsx
@@ -1,13 +1,18 @@
 // src/pages/login/LoginPage.tsx
 import { useState } from "react";
-import { Link, useNavigate } from "react-router-dom";
+import { Link, useNavigate, useSearchParams } from "react-router-dom";
 import { useAuthStore } from "../../store/auth.store";
+import { useWaitingStore } from "../../store/waiting.store";
 
 type TabType = "login" | "signup";
 
 export default function LoginPage() {
   const navigate = useNavigate();
+  const { enterQueue, isInQueue, leaveQueue } = useWaitingStore();
   const { login, signup } = useAuthStore();
+  const [searchParams] = useSearchParams();
+  const redirect = searchParams.get("redirect");
+  const eventId = searchParams.get("eventId");
 
   const [activeTab, setActiveTab] = useState<TabType>("login");
 
@@ -38,7 +43,13 @@ export default function LoginPage() {
       setLoginError(result.message);
       return;
     }
-    navigate(result.role === "admin" ? "/admin" : "/");
+    if(redirect === "/waiting" && eventId && isInQueue){
+      enterQueue(eventId);
+    }
+    navigate(
+      result.role === "admin" ? "/admin" : (redirect ?? "/"),
+      { state: eventId ? { eventId } : undefined, replace: true }
+    );
   };
 
   const handleSignup = () => {
@@ -66,7 +77,7 @@ export default function LoginPage() {
           {/* 좌측 패널 */}
           <div className="w-1/2 bg-[#2f6fcd] text-white p-[56px] flex flex-col justify-between">
             <div>
-              <Link to="/" className="flex items-end gap-2 mb-10 hover:opacity-90 transition">
+              <Link to="/" onClick={leaveQueue} className="flex items-end gap-2 mb-10 hover:opacity-90 transition">
                 <span className="text-[28px] font-extrabold tracking-tight">티키타카</span>
                 <span className="text-[13px] text-white/70 mb-[3px]">TIKITAKA</span>
               </Link>

--- a/src/pages/waiting/WaitingPage.tsx
+++ b/src/pages/waiting/WaitingPage.tsx
@@ -1,5 +1,7 @@
 // src/pages/waiting/WaitingPage.tsx
+import { useEffect } from "react";
 import { useNavigate } from "react-router-dom";
+import { useWaitingStore } from "../../store/waiting.store";
 
 // ── 더미 대기 상태
 const DUMMY_WAITING = {
@@ -16,6 +18,7 @@ const STEPS = ["대기열 입장", "대기 중", "좌석 선택", "결제"] as c
 
 export default function WaitingPage() {
   const navigate = useNavigate();
+  const { isInQueue, eventId: queueEventId, leaveQueue } = useWaitingStore();
 
   const { position, totalWaiting, estimatedMin, estimatedSec, remainingSeats } =
     DUMMY_WAITING;
@@ -26,9 +29,23 @@ export default function WaitingPage() {
     Math.round(((totalWaiting - position) / totalWaiting) * 100)
   );
 
+  useEffect(() => {
+    if (!isInQueue) {
+      navigate(queueEventId ? `/event/${queueEventId}` : "/", { replace: true });
+      return;
+    }
+    window.history.pushState(null, "", window.location.href);
+    const handlePopState = () => {
+      window.history.pushState(null, "", window.location.href);
+    };
+    window.addEventListener("popstate", handlePopState);
+    return () => window.removeEventListener("popstate", handlePopState);
+  }, []);
+
   const handleCancel = () => {
     if (window.confirm("대기열에서 이탈하시겠습니까? 현재 순번을 잃게 됩니다.")) {
-      navigate(-1);
+      leaveQueue();
+      navigate(`/event/${queueEventId}`);
     }
   };
 
@@ -139,6 +156,16 @@ export default function WaitingPage() {
           순번 도달 시 자동으로 좌석 선택 페이지로 이동합니다.
           입장 토큰 유효시간: <strong>10분</strong>
         </div>
+
+        <button
+          onClick={() => {
+            leaveQueue();
+            navigate(`/event/${queueEventId}`);
+          }}
+          className="w-full py-2.5 border border-gray-300 text-gray-500 rounded hover:bg-gray-50 text-[13.5px] transition mb-2"
+        >
+          ← 이벤트 상세로 돌아가기
+        </button>
 
         {/* 대기 취소 버튼 */}
         <button

--- a/src/router/Guards.tsx
+++ b/src/router/Guards.tsx
@@ -1,11 +1,21 @@
 // src/router/guards.tsx
-import { Navigate, Outlet } from "react-router-dom";
+import { Navigate, Outlet, useLocation } from "react-router-dom";
 import { useAuthStore } from "../store/auth.store";
+import { useWaitingStore } from "../store/waiting.store";
 
 // 로그인 필요 라우트 — 미로그인 시 /login 리다이렉트
 export function AuthGuard() {
   const currentUser = useAuthStore((s) => s.currentUser);
-  return currentUser ? <Outlet /> : <Navigate to="/login" replace />;
+  const { isInQueue, eventId: queueEventId } = useWaitingStore();
+  const location = useLocation();
+
+  if (!currentUser) {
+    if (isInQueue && queueEventId) {
+      return <Navigate to={`/login?redirect=/waiting&eventId=${queueEventId}`} replace />;
+    }
+    return <Navigate to={`/login?redirect=${encodeURIComponent(location.pathname)}`} replace />;
+  }
+  return <Outlet />;
 }
 
 // 어드민 전용 라우트 — 비어드민 시 / 리다이렉트
@@ -14,10 +24,4 @@ export function AdminGuard() {
   if (!currentUser) return <Navigate to="/" replace />;
   if (currentUser.role !== "admin") return <Navigate to="/" replace />;
   return <Outlet />;
-}
-
-// 로그인 상태에서 /login 접근 시 홈으로
-export function GuestGuard() {
-  const currentUser = useAuthStore((s) => s.currentUser);
-  return currentUser ? <Navigate to="/" replace /> : <Outlet />;
 }

--- a/src/router/Router.tsx
+++ b/src/router/Router.tsx
@@ -5,7 +5,7 @@ import HomeLayout from "./layouts/HomeLayout";
 import BaseLayout from "./layouts/BaseLayout";
 import BreadcrumbLayout from "./layouts/BreadcrumbLayout";
 import AdminLayout from "./layouts/AdminLayout";
-import { AuthGuard, AdminGuard, GuestGuard } from "./Guards";
+import { AuthGuard, AdminGuard } from "./Guards";
 
 import HomePage from "../pages/home/HomePage";
 import LoginPage from "../pages/login/LoginPage";
@@ -36,10 +36,8 @@ export default function Router() {
       <ScrollToTop />
       <Routes>
 
-        {/* 로그인 — 이미 로그인 시 홈으로 */}
-        <Route element={<GuestGuard />}>
-          <Route path="/login" element={<LoginPage />} />
-        </Route>
+        {/* 로그인 */}
+        <Route path="/login" element={<LoginPage />} />
 
         {/* 홈 — 누구나 */}
         <Route element={<HomeLayout />}>

--- a/src/store/waiting.store.ts
+++ b/src/store/waiting.store.ts
@@ -1,0 +1,16 @@
+// src/store/waiting.store.ts
+import { create } from "zustand";
+
+interface WaitingState {
+  isInQueue: boolean;
+  eventId: string | null;
+  enterQueue: (eventId: string) => void;
+  leaveQueue: () => void;
+}
+
+export const useWaitingStore = create<WaitingState>()((set) => ({
+  isInQueue: false,
+  eventId: null,
+  enterQueue: (eventId) => set({ isInQueue: true, eventId }),
+  leaveQueue: () => set({ isInQueue: false, eventId: null }),
+}));


### PR DESCRIPTION
# 💡 Issue
Feat: 이벤트 상세 동작 및 대기열 진입 #5

# 🌱 Key changes
- [x] 예매하기 버튼 클릭 시 이동 분기
- [x] 로그인 성공 후 redirect 처리
- [x] 예매하기 버튼으로 로그인 과정 수행한 경우 대기열 진입
- [x] 로그인 버튼으로 과정 수행한 경우 기존 페이지로 복귀
- [x] 대기열 진입 페이지 큐 추가
- [x] 대기열 페이지에 비정상 진입 방지(ex. 뒤로가기)
- [x] 대기열 페이지에서 타 페이지 이동 제어(이전 페이지 버튼, 헤더 로고)
- [x] 대기열 페이지에서 바로 로그아웃한 경우 로그인 페이지로 이동, 해당 경우 즉시 로그인 시 대기열 재진입
- [x] 대기열 페이지에서 바로 로그아웃 후 로그인 페이지 이외의 url로 이동 후 복귀한 경우, 로그인 시 홈으로 이동

# ✅ To Reviewers

# 📸 스크린샷
