### PR TITLE
feat : 헤더 및 알림 변경

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -2,13 +2,33 @@
 import { Link, useLocation, useNavigate } from "react-router-dom";
 import { useAuthStore } from "../store/auth.store";
 import { useWaitingStore } from "../store/waiting.store";
+import { useEffect, useRef, useState } from "react";
+
+const DUMMY_NOTIFICATIONS = Array.from({ length: 20 }, (_, i) => ({
+  id: i,
+  message: i % 3 === 0 ? "예매가 완료되었습니다." : i % 3 === 1 ? "공연 D-7 알림입니다." : "결제가 취소되었습니다.",
+  time: `${i + 1}시간 전`,
+  unread: i < 3,
+}));
 
 export default function Header() {
   const navigate = useNavigate();
   const location = useLocation();
   const { isInQueue, leaveQueue } = useWaitingStore();
   const currentUser = useAuthStore((s) => s.currentUser);
+  const [showNotifications, setShowNotifications] = useState(false);
   const logout = useAuthStore((s) => s.logout);
+
+  const notifRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+  const handleClickOutside = (e: MouseEvent) => {
+    if (notifRef.current && !notifRef.current.contains(e.target as Node)) {
+      setShowNotifications(false);
+    }
+  };
+  document.addEventListener("mousedown", handleClickOutside);
+  return () => document.removeEventListener("mousedown", handleClickOutside);
+}, []);
 
   const handleLogout = () => {
     if (isInQueue) {
@@ -39,11 +59,41 @@ export default function Header() {
             </button>
           ) : (
             <>
-              <span className="text-white/90 text-[13px]">{currentUser.name} 님</span>
+              <Link to="/mypage" className="text-white/90 text-[13px]">{currentUser.name} 님</Link>
 
-              <Link to="/mypage" className="relative text-white text-[16px] cursor-pointer">
-                🔔
-              </Link>
+              <div className="relative" ref={notifRef}>
+                <button
+                  onClick={() => setShowNotifications((v) => !v)}
+                  className="relative text-white text-[16px] cursor-pointer"
+                >
+                  🔔
+                </button>
+                {showNotifications && (
+                  <div className="absolute right-0 top-[32px] w-[320px] bg-white border border-gray-200 rounded-lg shadow-xl z-50">
+                    <div className="px-4 py-3 border-b border-gray-200 flex items-center justify-between">
+                      <span className="text-[14px] font-bold text-gray-800">알림</span>
+                      <button onClick={() => setShowNotifications(false)} className="text-gray-400 text-[12px]">✕</button>
+                    </div>
+                    <div className="max-h-[400px] overflow-y-auto">
+                      {DUMMY_NOTIFICATIONS.map((n) => (
+                        <div key={n.id} className={`px-4 py-3 border-b border-gray-100 last:border-0 ${n.unread ? "bg-blue-50" : ""}`}>
+                          <p className="text-[13px] text-gray-700">{n.message}</p>
+                          <p className="text-[11.5px] text-gray-400 mt-0.5">{n.time}</p>
+                        </div>
+                      ))}
+                    </div>
+                    <div className="px-4 py-2.5 border-t border-gray-200 text-center">
+                      <Link
+                        to="/mypage?tab=notifications"
+                        onClick={() => setShowNotifications(false)}
+                        className="text-[12.5px] text-[#1a6ad4]"
+                      >
+                        전체 알림 보기
+                      </Link>
+                    </div>
+                  </div>
+                )}
+              </div>
 
               {currentUser.role === "admin" && (
                 <Link

--- a/src/pages/mypage/MyPage.tsx
+++ b/src/pages/mypage/MyPage.tsx
@@ -4,11 +4,14 @@ import BookingListTab from "./tabs/BookingListTab";
 import NotificationTab from "./tabs/NotificationTab";
 import ProfileTab from "./tabs/ProfileTab";
 import PasswordTab from "./tabs/PasswordTab";
+import { useSearchParams } from "react-router-dom";
+import NotificationsTab from "./tabs/NotificationsTab";
 
-type TabKey = "bookings" | "notification" | "profile" | "password";
+type TabKey = "bookings" | "notifications" | "notification" | "profile" | "password";
 
 const NAV_ITEMS: { key: TabKey; label: string }[] = [
   { key: "bookings",     label: "예매 내역" },
+  { key: "notifications", label: "알림 기록" },
   { key: "notification", label: "알림 설정" },
   { key: "profile",      label: "회원 정보 수정" },
   { key: "password",     label: "비밀번호 변경" },
@@ -20,14 +23,17 @@ const DUMMY_USER = {
 };
 
 export default function MyPage() {
-  const [activeTab, setActiveTab] = useState<TabKey>("bookings");
+  const [searchParams] = useSearchParams();
+  const [activeTab, setActiveTab] = useState<TabKey>(searchParams.get("tab") as TabKey) ?? "bookings";
 
   const renderTab = () => {
     switch (activeTab) {
       case "bookings":     return <BookingListTab />;
+      case "notifications": return <NotificationsTab />;
       case "notification": return <NotificationTab />;
       case "profile":      return <ProfileTab />;
       case "password":     return <PasswordTab />;
+      default: return <BookingListTab />;
     }
   };
 

--- a/src/pages/mypage/tabs/NotificationsTab.tsx
+++ b/src/pages/mypage/tabs/NotificationsTab.tsx
@@ -1,0 +1,90 @@
+// src/pages/mypage/tabs/NotificationsTab.tsx
+import { useState } from "react";
+
+type NotifCategory = "all" | "booking" | "performance" | "payment";
+
+const CATEGORY_LABELS: { key: NotifCategory; label: string }[] = [
+  { key: "all",         label: "전체" },
+  { key: "booking",     label: "예매" },
+  { key: "performance", label: "공연" },
+  { key: "payment",     label: "결제" },
+];
+
+const DUMMY_ALL_NOTIFICATIONS = Array.from({ length: 50 }, (_, i) => ({
+  id: i,
+  category: i % 3 === 0 ? "booking" : i % 3 === 1 ? "performance" : "payment" as NotifCategory,
+  message: i % 3 === 0
+    ? "아이유 THE GOLDEN HOUR WORLD TOUR 예매가 완료되었습니다."
+    : i % 3 === 1
+    ? "BTS WORLD TOUR 공연 D-7 알림입니다."
+    : "아이유 THE GOLDEN HOUR WORLD TOUR 결제가 취소되었습니다.",
+  time: `${i + 1}시간 전`,
+  unread: i < 5,
+}));
+
+const CATEGORY_ICON: Record<NotifCategory, string> = {
+  all:         "🔔",
+  booking:     "🎫",
+  performance: "🎤",
+  payment:     "💳",
+};
+
+export default function NotificationsTab() {
+  const [activeCategory, setActiveCategory] = useState<NotifCategory>("all");
+
+  const filtered = DUMMY_ALL_NOTIFICATIONS.filter(
+    (n) => activeCategory === "all" || n.category === activeCategory
+  );
+
+  return (
+    <div className="bg-white border border-gray-200 rounded-md overflow-hidden">
+      {/* 헤더 */}
+      <div className="px-5 py-4 border-b border-gray-200 bg-gray-50 flex items-center justify-between">
+        <span className="text-[14px] font-bold">알림 기록</span>
+        <span className="text-[12.5px] text-gray-400">전체 {DUMMY_ALL_NOTIFICATIONS.length}개</span>
+      </div>
+
+      {/* 카테고리 필터 */}
+      <div className="flex gap-2 px-5 py-3 border-b border-gray-200">
+        {CATEGORY_LABELS.map(({ key, label }) => (
+          <button
+            key={key}
+            onClick={() => setActiveCategory(key)}
+            className={`px-3 py-1.5 rounded-full text-[12.5px] font-medium transition ${
+              activeCategory === key
+                ? "bg-[#1a6ad4] text-white"
+                : "bg-gray-100 text-gray-500 hover:bg-gray-200"
+            }`}
+          >
+            {label}
+          </button>
+        ))}
+      </div>
+
+      {/* 알림 목록 */}
+      <div>
+        {filtered.length === 0 ? (
+          <div className="py-16 text-center text-gray-300 text-[13px]">알림이 없습니다</div>
+        ) : (
+          filtered.map((n) => (
+            <div
+              key={n.id}
+              className={`flex items-start gap-3 px-5 py-3.5 border-b border-gray-100 last:border-0 ${
+                n.unread ? "bg-blue-50" : ""
+              }`}
+            >
+              <span className="text-[18px] mt-0.5">{CATEGORY_ICON[n.category as NotifCategory]}</span>
+              <div className="flex-1">
+                <p className="text-[13.5px] text-gray-700">{n.message}</p>
+                <p className="text-[11.5px] text-gray-400 mt-0.5">{n.time}</p>
+              </div>
+              {n.unread && (
+                <span className="w-2 h-2 rounded-full bg-[#1a6ad4] mt-1.5 shrink-0" />
+              )}
+            </div>
+          ))
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
# 💡 Issue
Feat: 헤더 및 알림 변경 #11

# 🌱 Key changes
- [x] 마이페이지 이동 변경(알림 -> 회원 이름)
- [x] 알림 드롭다운 구현(최신 20개 알림)
- [x] 마이페이지 진입 시 초기 화면 예매 내역으로 고정
- [x] 전체 알림 기록 탭 추가

# ✅ To Reviewers

# 📸 스크린샷
